### PR TITLE
Encode more HTML entites

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -196,6 +196,9 @@ function! s:XmlEncode(str)
   let str = substitute(str,'<','\&lt;','g')
   let str = substitute(str,'>','\&gt;','g')
   let str = substitute(str,'"','\&quot;','g')
+  for key in keys(g:unimpaired_html_entities)
+      let str = substitute(str, nr2char(g:unimpaired_html_entities[key]),'\&'.key.';','g')
+  endfor
   return str
 endfunction
 


### PR DESCRIPTION
Hi,

I wanted to use unimpaired as a full replacement for my own crappy HTML encode/decode plugin, so I added a foreach loop that encodes all entities available in g:unimpaired_html_entities. Now it's everything I ever wanted! (in a html entity encoder)

I suspect that you left out this functionality for a reason, so I don't expect you to merge it. Just putting it out there :)

Cheers,
Sung
