### PR TITLE
fix submodule usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
when using pathogen and git submodules this keeps git status from
complaining about untracked content
