### PR TITLE
Add mappings for :tprevious and :tnext

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -31,6 +31,10 @@ is "args" and for the "q" commands is "quickfix".
 *]q* |:cnext|
 *[Q* |:cfirst|
 *]Q* |:clast|
+*[t* |:tprevious|
+*]t* |:tnext|
+*[T* |:tfirst|
+*]T* |:tlast|
 
                                                 *[o*
 [o                      Go to the file preceding the current one

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -29,6 +29,7 @@ call s:MapNextFamily('a','')
 call s:MapNextFamily('b','b')
 call s:MapNextFamily('l','l')
 call s:MapNextFamily('q','c')
+call s:MapNextFamily('t','t')
 
 function! s:entries(path)
   let path = substitute(a:path,'[\\/]$','','')


### PR DESCRIPTION
This is a pretty simple patch, it adds `[t` and `]t` as mappings for `:tprevious` and `:tnext`. I noticed this conflicts with pull request #5, but to me, this one has been more useful and feels somewhat more intuitive.
