### PR TITLE
Add diff3 conflict marker jump bindings

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -74,29 +74,35 @@ nnoremap <silent> <Plug>unimpairedOPrevious :<C-U>edit `=<SID>FileByOffset(-v:co
 nmap ]o <Plug>unimpairedONext
 nmap [o <Plug>unimpairedOPrevious
 
-nmap [, :call search('^[<=>]\{7\}','bW')<CR>
-nmap ], :call search('^[<=>]\{7\}','W')<CR>
-omap [, V:call search('^[<=>]\{7\}','bW')<CR>
-omap ], V:call search('^[<=>]\{7\}','W')<CR>
-xmap [, :<C-U>exe 'norm! gv'<Bar>call search('^[<=>]\{7\}','bW')<CR>
-xmap ], :<C-U>exe 'norm! gv'<Bar>call search('^[<=>]\{7\}','W')<CR>
+nmap [, :call search('^[<=\|>]\{7\}','bW')<CR>
+nmap ], :call search('^[<=\|>]\{7\}','W')<CR>
+omap [, V:call search('^[<=\|>]\{7\}','bW')<CR>
+omap ], V:call search('^[<=\|>]\{7\}','W')<CR>
+xmap [, :<C-U>exe 'norm! gv'<Bar>call search('^[<=\|>]\{7\}','bW')<CR>
+xmap ], :<C-U>exe 'norm! gv'<Bar>call search('^[<=\|>]\{7\}','W')<CR>
 nmap [< :call search('^<<<<<<<','bW')<CR>
 nmap [= :call search('^=======','bW')<CR>
+nmap [\| :call search('^\|\|\|\|\|\|\|','bW')<CR>
 nmap [> :call search('^>>>>>>>','bW')<CR>
 nmap ]< :call search('^<<<<<<<','W')<CR>
 nmap ]= :call search('^=======','W')<CR>
+nmap ]\| :call search('^\|\|\|\|\|\|\|','W')<CR>
 nmap ]> :call search('^>>>>>>>','W')<CR>
 xmap [< :<C-U>exe 'norm! gv'<Bar>call search('^<<<<<<<','bW')<CR>
 xmap [= :<C-U>exe 'norm! gv'<Bar>call search('^=======','bW')<CR>
+xmap [\| :<C-U>exe 'norm! gv'<Bar>call search('^\|\|\|\|\|\|\|','bW')<CR>
 xmap [> :<C-U>exe 'norm! gv'<Bar>call search('^>>>>>>>','bW')<CR>
 xmap ]< :<C-U>exe 'norm! gv'<Bar>call search('^<<<<<<<','W')<CR>
 xmap ]= :<C-U>exe 'norm! gv'<Bar>call search('^=======','W')<CR>
+xmap ]\| :<C-U>exe 'norm! gv'<Bar>call search('^\|\|\|\|\|\|\|','W')<CR>
 xmap ]> :<C-U>exe 'norm! gv'<Bar>call search('^>>>>>>>','W')<CR>
 omap [< V:call search('^<<<<<<<','bW')<CR>
 omap [= V:call search('^=======','bW')<CR>
+omap [\| V:call search('^\|\|\|\|\|\|\|','bW')<CR>
 omap [> V:call search('^>>>>>>>','bW')<CR>
 omap ]< V:call search('^<<<<<<<','W')<CR>
 omap ]= V:call search('^=======','W')<CR>
+omap ]\| V:call search('^\|\|\|\|\|\|\|','W')<CR>
 omap ]> V:call search('^>>>>>>>','W')<CR>
 
 " }}}1


### PR DESCRIPTION
In git, when merge.conflictstyle is set to diff3, the common ancestors
are marked with '|||||||' at the beginning of the line.
