### PR TITLE
base64 encode/decode + README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ line with the one above or below it.
 
 There are mappings for encoding and decoding. `[x` and `]x` encode and
 decode XML (and HTML). `[u` and `]u` encode and decode URLs. `[y` and
-`]y` do C String style escaping.
+`]y` do C String style escaping. `[Y` and `]Y` encode and decode Base64.
 
 And in the miscellaneous category, there's `[o` and `]o` to go to the
 next/previous file in the directory, and `[n` and `]n` to jump between

--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -104,15 +104,15 @@ Mnenomic: encoding always comes before decoding; "[" always comes before "]".
 ]yy
 {Visual}]y
 
-                                                *[6* *[66* *v_[6*
-[6{motion}              Base64 encode.
-[66                     foo bar => Zm9vIGJhcg==
-{Visual}[6
+                                                *[Y* *[YY* *v_[Y*
+[Y{motion}              Base64 encode.
+[YY                     foo bar => Zm9vIGJhcg==
+{Visual}[Y
 
-                                                *]6* *]66* *v_]6*
-]6{motion}              Base64 decode
-]66                     Input length must be a multiple of 4.
-{Visual}]6
+                                                *]Y* *]YY* *v_]Y*
+]Y{motion}              Base64 decode
+]YY                     Input length must be a multiple of 4.
+{Visual}]Y
 
 TODO                                            *unimpaired-todo*
 

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -390,8 +390,8 @@ call s:MapTransform('UrlEncode','[u')
 call s:MapTransform('UrlDecode',']u')
 call s:MapTransform('XmlEncode','[x')
 call s:MapTransform('XmlDecode',']x')
-call s:MapTransform('Base64Encode','[6')
-call s:MapTransform('Base64Decode',']6')
+call s:MapTransform('Base64Encode','[Y')
+call s:MapTransform('Base64Decode',']Y')
 
 " }}}1
 


### PR DESCRIPTION
Hello,

I added base64 support (encoding/decoding) to unimpaired and mapped it to `[6` and `]6`.

Also, there is a proposal for a markdown README for your plug-in.
