### PR TITLE
Let [e and ]e work on closed fold in normal mode

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -144,7 +144,22 @@ nmap ]<Space> <Plug>unimpairedBlankDown
 
 function! s:Move(cmd, count, map) abort
   normal! m`
-  exe 'move'.a:cmd.a:count
+
+  let range = ''
+  let address = ''
+
+  if foldclosed(line('.')) >= 0
+    let start_fold = foldclosed(line('.'))
+    let end_fold = foldclosedend(line('.'))
+
+    let range = start_fold.','.end_fold
+
+    if a:map =~ 'Down'
+      let address = end_fold
+    endif
+  endif
+
+  exe range.'move'.address.a:cmd.a:count
   norm! ``
   silent! call repeat#set("\<Plug>unimpairedMove".a:map, a:count)
 endfunction


### PR DESCRIPTION
As I read in the vim documentation, closed fold should be treated as single line, so I thought that this could be helpful to keep all consistent. I'm a new to vimscript so if it is poorly structured or if could be improved with some vimscript trick let me know.
