### PR TITLE
Change `*prfile` to `*pfile`

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -22,7 +22,7 @@ function! s:MapNextFamily(map,cmd)
   execute 'nmap <silent> ['.toupper(a:map).' '.map.'First'
   execute 'nmap <silent> ]'.toupper(a:map).' '.map.'Last'
   if exists(':'.a:cmd.'nfile')
-    execute 'nnoremap <silent> '.map.'PFile :<C-U>exe "'.a:cmd.'prfile'.end
+    execute 'nnoremap <silent> '.map.'PFile :<C-U>exe "'.a:cmd.'pfile'.end
     execute 'nnoremap <silent> '.map.'NFile :<C-U>exe "'.a:cmd.'nfile'.end
     execute 'nmap <silent> [<C-'.a:map.'> '.map.'PFile'
     execute 'nmap <silent> ]<C-'.a:map.'> '.map.'NFile'


### PR DESCRIPTION
]<C-Q> works great for me, but [<C-Q> complains:

```
E492: Not an editor command: cprfile
```

:cpfile is valid but :cprfile is not so `[<C-Q>` wasn't working.

Also you were right about flow control... I did need to disable it before I could use <C-q> in cli vim.
