### PR TITLE
Setup paste also disable mouse

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -227,7 +227,9 @@ nnoremap cox :set <C-R>=&cursorline && &cursorcolumn ? 'nocursorline nocursorcol
 
 function! s:setup_paste() abort
   let s:paste = &paste
+  let s:mouse = &mouse
   set paste
+  set mouse=
 endfunction
 
 nnoremap <silent> <Plug>unimpairedPaste :call <SID>setup_paste()<CR>
@@ -246,7 +248,9 @@ augroup unimpaired_paste
   autocmd InsertLeave *
         \ if exists('s:paste') |
         \   let &paste = s:paste |
+        \   let &mouse = s:mouse |
         \   unlet s:paste |
+        \   unlet s:mouse |
         \ endif
 augroup END
 


### PR DESCRIPTION
Paste using primary select, helpful in case of Vim compiled without X or over SSH
