### PR TITLE
Move to next/previous help-file tag with ]g and [g

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -56,6 +56,12 @@ is "args" and for the "q" commands is "quickfix".
 ]n                      Go to the next SCM conflict marker or diff/patch hunk.
                         Try d]n inside a conflict.
 
+                                                *[g*
+[g                      Move the cursor to the next help-file tag.
+
+                                                *]g*
+]g                      Move the cursor to the previous help-file tag.
+
 LINE OPERATIONS                                 *unimpaired-lines*
 
                                                 *[<Space>*

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -144,6 +144,19 @@ function! s:ContextMotion(reverse)
 endfunction
 
 " }}}1
+" Help tag next, previous {{{1
+
+nmap [g <Plug>unimpairedHelpTagPrevious
+nmap ]g <Plug>unimpairedHelpTagNext
+
+nnoremap <silent> <Plug>unimpairedHelpTagPrevious :call <SID>HelpTag(1)<CR>
+nnoremap <silent> <Plug>unimpairedHelpTagNext     :call <SID>HelpTag(0)<CR>
+
+function! s:HelpTag(reverse)
+  call search('|\S\+|', a:reverse ? 'bW' : 'W')
+endfunction
+
+" }}}1
 " Line operations {{{1
 
 function! s:BlankUp(count) abort


### PR DESCRIPTION
- Makes easier to explore vim help files by moving the cursor directly between tags before  jumping to it with `ctrl-]`.
- Proper documentation has been added to the plugin help-file.
- `]g` and `[g` has been chosen because keep some relation with tags as `g]` is a built in vim command (and `]t` is taken )
