### PR TITLE
Fix endless loop with `[f` and no file

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -51,6 +51,9 @@ endfunction
 
 function! s:FileByOffset(num)
   let file = expand('%:p')
+  if file == ''
+    let file = getcwd() . '/'
+  endif
   let num = a:num
   while num
     let files = s:entries(fnamemodify(file,':h'))


### PR DESCRIPTION
Using `[f`/`]f` in an empty buffer would result in an empty loop,
because `expand('%:p')` is empty in that case.

Use `getcwd`.'/' in this case, so that `expand(':h')` resolves in its
directory.

That being said, it's not really clear how parent directories should be handled: it seems to be supported, although the doc says that it will use the current directory (only?).

There is also a `" TODO: walk back up the tree and continue`.

In case of traversing into parent directories, `num` should probably get adjusted, so that it points at the best entry for the initial `file`.
