### PR TITLE
Alter conflict marker regex to work in recent Fedora.  Fixes #98.

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -110,7 +110,7 @@ onoremap <silent> <Plug>unimpairedContextPrevious :call <SID>ContextMotion(1)<CR
 onoremap <silent> <Plug>unimpairedContextNext     :call <SID>ContextMotion(0)<CR>
 
 function! s:Context(reverse)
-  call search('^@@ .* @@\|^[<=>|]\{7}[<=>|]\@!', a:reverse ? 'bW' : 'W')
+  call search('^\(@@ .* @@\|[<=>|]\{7}[<=>|]\@!\)', a:reverse ? 'bW' : 'W')
 endfunction
 
 function! s:ContextMotion(reverse)


### PR DESCRIPTION
The Vim package in newer versions of Fedora (22+) does not work
correctly with a regex of the form `^Thing|^OtherThing`.  See
https://bugzilla.redhat.com/show_bug.cgi?id=1241233