### PR TITLE
Use :nohlsearch before setting 'nohlsearch'

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -76,7 +76,7 @@ On	Off	Toggle	Option
 *[ob*	*]ob*	*cob*	'background' (dark is off, light is on)
 *[oc*	*]oc*	*coc*	'cursorline'
 *[od*	*]od*	*cod*	'diff' (actually |:diffthis| / |:diffoff|)
-*[oh*	*]oh*	*coh*	'hlsearch'
+*[oh*	*]oh*	*coh*	'hlsearch' (coh: first |:nohlsearch|, then |'nohlsearch'|)
 *[oi*	*]oi*	*coi*	'ignorecase'
 *[ol*	*]ol*	*col*	'list'
 *[on*	*]on*	*con*	'number'

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -222,7 +222,9 @@ call s:option_map('u', 'cursorcolumn', 'setlocal')
 nnoremap [od :diffthis<CR>
 nnoremap ]od :diffoff<CR>
 nnoremap cod :<C-R>=&diff ? 'diffoff' : 'diffthis'<CR><CR>
-call s:option_map('h', 'hlsearch', 'set')
+nnoremap [oh :set hlsearch<CR>
+nnoremap ]oh :set nohlsearch<CR>
+nnoremap coh :<C-R>=eval(&hls) ? (v:hlsearch ? 'noh' : 'set nohls') : 'set hls'<CR><CR>
 call s:option_map('i', 'ignorecase', 'set')
 call s:option_map('l', 'list', 'setlocal')
 call s:option_map('n', 'number', 'setlocal')


### PR DESCRIPTION
I've been using a `'<leader>'` mapping for `:nohlsearch` for quite some time, but after installing this plugin that mapping seems sub-optimal :)

My first thought was changing that mapping to `coh` (overwriting the plugin mapping).
But this is a common workflow, thus maybe it would be better if unimpaired handled it. The old behavior could still be achieved through `]oh`.
