### PR TITLE
Add mappings for syntax toggling

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -86,6 +86,7 @@ On	Off	Toggle	Option
 *[ov*	*]ov*	*cov*	'virtualedit'
 *[ow*	*]ow*	*cow*	'wrap'
 *[ox*	*]ox*	*cox*	'cursorline' 'cursorcolumn' (x as in crosshairs)
+*[oy*	*]oy*	*coy*	'syntax'
 
 PASTING                                         *unimpaired-pasting*
 

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -232,6 +232,9 @@ call s:option_map('w', 'wrap', 'setlocal')
 nnoremap [ox :set cursorline cursorcolumn<CR>
 nnoremap ]ox :set nocursorline nocursorcolumn<CR>
 nnoremap cox :set <C-R>=&cursorline && &cursorcolumn ? 'nocursorline nocursorcolumn' : 'cursorline cursorcolumn'<CR><CR>
+nnoremap [oy :setlocal syntax=ON<CR>
+nnoremap ]oy :setlocal syntax=OFF<CR>
+nnoremap coy :setlocal syntax=<C-R>=&l:syntax ==# 'OFF' ? 'ON' : 'OFF'<CR><CR>
 nnoremap [ov :set virtualedit+=all<CR>
 nnoremap ]ov :set virtualedit-=all<CR>
 nnoremap cov :set <C-R>=(&virtualedit =~# "all") ? 'virtualedit-=all' : 'virtualedit+=all'<CR><CR>


### PR DESCRIPTION
One may use this mappings due to performance reasons. In addition sometimes there is a code that is much easier to read with syntax highlighting turned off.