### PR TITLE
Add [oD ]oD coD mappings for 'windo diff'

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -76,6 +76,7 @@ On	Off	Toggle	Option
 *[ob*	*]ob*	*cob*	'background' (dark is off, light is on)
 *[oc*	*]oc*	*coc*	'cursorline'
 *[od*	*]od*	*cod*	'diff' (actually |:diffthis| / |:diffoff|)
+*[oD*	*]oD*	*coD*	'windo diff' (|:diffthis| / |:diffoff|)
 *[oh*	*]oh*	*coh*	'hlsearch'
 *[oi*	*]oi*	*coi*	'ignorecase'
 *[ol*	*]ol*	*col*	'list'

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -233,6 +233,9 @@ call s:option_map('u', 'cursorcolumn', 'setlocal')
 nnoremap [od :diffthis<CR>
 nnoremap ]od :diffoff<CR>
 nnoremap cod :<C-R>=&diff ? 'diffoff' : 'diffthis'<CR><CR>
+nnoremap [oD :windo diffthis<CR>
+nnoremap ]oD :windo diffoff<CR>
+nnoremap coD :windo <C-R>=&diff ? 'diffoff' : 'diffthis'<CR><CR>
 call s:option_map('h', 'hlsearch', 'set')
 call s:option_map('i', 'ignorecase', 'set')
 call s:option_map('l', 'list', 'setlocal')


### PR DESCRIPTION
as the lower case [cod, etc. do only 'diffthis' or 'diffoff' in the current window, and this then needs to be repeated for at least the second window to be compared. A usual workspace with two split windows to be compared would only need a 'windo diffthis'...