### PR TITLE
Make check for existing mappings conservative.

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -255,7 +255,7 @@ call s:map('n', '=ov', ':set <C-R>=(&virtualedit =~# "all") ? "virtualedit-=all"
 call s:map('n', '[ox', ':set cursorline cursorcolumn<CR>')
 call s:map('n', ']ox', ':set nocursorline nocursorcolumn<CR>')
 call s:map('n', '=ox', ':set <C-R>=<SID>cursor_options()<CR><CR>')
-if empty(maparg('co', 'n'))
+if empty(mapcheck('co', 'n'))
   nmap co =o
 endif
 


### PR DESCRIPTION
On my config the `co` mapping is ambiguous with a pre-existing one, leading to undesirable waiting/timeout behaviour. Since it is my understanding that this is a legacy mapping which is already guarded by a `maparg` check, this PR makes the guard more conservative by using `mapcheck` instead—only installing the mapping if there is no ambiguity.