### PR TITLE
Additional mappings for toggling options & switching between tabs

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -85,7 +85,7 @@ On	Off	Toggle	Option
 *[oh*	*]oh*	*=oh*	'hlsearch'
 *[oi*	*]oi*	*=oi*	'ignorecase'
 *[oI*	*]oI*	*=oI*	'incsearch'
-*[ol*	*]ol*	*=ol*	'list' (toggles IndentLines if installed)
+*[ol*	*]ol*	*=ol*	'list'
 *[on*	*]on*	*=on*	'number'
 *[or*	*]or*	*=or*	'relativenumber'
 *[os*	*]os*	*=os*	'spell'

--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -75,10 +75,13 @@ OPTION TOGGLING                                 *unimpaired-toggling*
 On	Off	Toggle	Option
 *[ob*	*]ob*	*cob*	'background' (dark is off, light is on)
 *[oc*	*]oc*	*coc*	'cursorline'
+*[oC*	*]oC*	*coC*	'colorcolumn'
 *[od*	*]od*	*cod*	'diff' (actually |:diffthis| / |:diffoff|)
+*[of*	*]of*	*cof*	'foldcolumn'
 *[oh*	*]oh*	*coh*	'hlsearch'
 *[oi*	*]oi*	*coi*	'ignorecase'
-*[ol*	*]ol*	*col*	'list'
+*[oI*	*]oI*	*coI*	'incsearch'
+*[ol*	*]ol*	*col*	'list' (toggles IndentLines if installed)
 *[on*	*]on*	*con*	'number'
 *[or*	*]or*	*cor*	'relativenumber'
 *[os*	*]os*	*cos*	'spell'

--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -15,30 +15,34 @@ The following maps all correspond to normal mode commands.  If a count is
 given, it becomes an argument to the command.  A mnemonic for the "a" commands
 is "args" and for the "q" commands is "quickfix".
 
-*[a*     |:previous|
-*]a*     |:next|
-*[A*     |:first|
-*]A*     |:last|
-*[b*     |:bprevious|
-*]b*     |:bnext|
-*[B*     |:bfirst|
-*]B*     |:blast|
-*[l*     |:lprevious|
-*]l*     |:lnext|
-*[L*     |:lfirst|
-*]L*     |:llast|
-*[<C-L>* |:lpfile|
-*]<C-L>* |:lnfile|
-*[q*     |:cprevious|
-*]q*     |:cnext|
-*[Q*     |:cfirst|
-*]Q*     |:clast|
-*[<C-Q>* |:cpfile| (Note that <C-Q> only works in a terminal if you disable
-*]<C-Q>* |:cnfile| flow control: stty -ixon)
-*[t*     |:tprevious|
-*]t*     |:tnext|
-*[T*     |:tfirst|
-*]T*     |:tlast|
+*[a*       |:previous|
+*]a*       |:next|
+*[A*       |:first|
+*]A*       |:last|
+*[b*       |:bprevious|
+*]b*       |:bnext|
+*[B*       |:bfirst|
+*]B*       |:blast|
+*[l*       |:lprevious|
+*]l*       |:lnext|
+*[L*       |:lfirst|
+*]L*       |:llast|
+*[<C-L>*   |:lpfile|
+*]<C-L>*   |:lnfile|
+*[q*       |:cprevious|
+*]q*       |:cnext|
+*[Q*       |:cfirst|
+*]Q*       |:clast|
+*[<C-Q>*   |:cpfile| (Note that <C-Q> only works in a terminal if you disable
+*]<C-Q>*   |:cnfile| flow control: stty -ixon)
+*[t*       |:tprevious|
+*]t*       |:tnext|
+*[T*       |:tfirst|
+*]T*       |:tlast|
+*[<Tab>*   |:tabprevious|
+*]<Tab>*   |:tabnext|
+*[<S-Tab>* |:tabfirst|
+*]<S-Tab>* |:tablast|
 
                                                 *[f*
 [f                      Go to the file preceding the current one

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -16,6 +16,7 @@ endfunction
 " Next and previous {{{1
 
 function! s:MapNextFamily(map,cmd) abort
+  let key = (a:map ==# 'tab' ? '<Tab>' : a:map)
   let map = '<Plug>unimpaired'.toupper(a:map)
   let cmd = '".(v:count ? v:count : "")."'.a:cmd
   let end = '"<CR>'.(a:cmd == 'l' || a:cmd == 'c' ? 'zv' : '')
@@ -23,10 +24,10 @@ function! s:MapNextFamily(map,cmd) abort
   execute 'nnoremap <silent> '.map.'Next     :<C-U>exe "'.cmd.'next'.end
   execute 'nnoremap <silent> '.map.'First    :<C-U>exe "'.cmd.'first'.end
   execute 'nnoremap <silent> '.map.'Last     :<C-U>exe "'.cmd.'last'.end
-  call s:map('n', '['.        a:map , map.'Previous')
-  call s:map('n', ']'.        a:map , map.'Next')
-  call s:map('n', '['.toupper(a:map), map.'First')
-  call s:map('n', ']'.toupper(a:map), map.'Last')
+  call s:map('n', '['.        key , map.'Previous')
+  call s:map('n', ']'.        key , map.'Next')
+  call s:map('n', '['.(a:map ==# 'tab' ? '<S-Tab>' : toupper(key)), map.'First')
+  call s:map('n', ']'.(a:map ==# 'tab' ? '<S-Tab>' : toupper(key)), map.'Last')
   if exists(':'.a:cmd.'nfile')
     execute 'nnoremap <silent> '.map.'PFile :<C-U>exe "'.cmd.'pfile'.end
     execute 'nnoremap <silent> '.map.'NFile :<C-U>exe "'.cmd.'nfile'.end
@@ -40,6 +41,7 @@ call s:MapNextFamily('b','b')
 call s:MapNextFamily('l','l')
 call s:MapNextFamily('q','c')
 call s:MapNextFamily('t','t')
+call s:MapNextFamily('tab', 'tab')
 
 function! s:entries(path)
   let path = substitute(a:path,'[\\/]$','','')

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -223,18 +223,27 @@ nnoremap [od :diffthis<CR>
 nnoremap ]od :diffoff<CR>
 nnoremap cod :<C-R>=&diff ? 'diffoff' : 'diffthis'<CR><CR>
 call s:option_map('h', 'hlsearch', 'set')
+call s:option_map('I', 'incsearch', 'set')
 call s:option_map('i', 'ignorecase', 'set')
-call s:option_map('l', 'list', 'setlocal')
 call s:option_map('n', 'number', 'setlocal')
 call s:option_map('r', 'relativenumber', 'setlocal')
 call s:option_map('s', 'spell', 'setlocal')
 call s:option_map('w', 'wrap', 'setlocal')
+nnoremap [of :setlocal foldcolumn=4<CR>
+nnoremap ]of :setlocal foldcolumn=0<CR>
+nnoremap cof :setlocal fdc=<C-R>=&fdc == 0 ? 4 : 0<CR><CR>
+nnoremap [oC :setlocal colorcolumn=+1<CR>
+nnoremap ]oC :setlocal colorcolumn=<CR>
+nnoremap coC :setlocal cc=<C-R>=&cc == '' ? '+1' : ''<CR><CR>
 nnoremap [ox :set cursorline cursorcolumn<CR>
 nnoremap ]ox :set nocursorline nocursorcolumn<CR>
 nnoremap cox :set <C-R>=&cursorline && &cursorcolumn ? 'nocursorline nocursorcolumn' : 'cursorline cursorcolumn'<CR><CR>
 nnoremap [ov :set virtualedit+=all<CR>
 nnoremap ]ov :set virtualedit-=all<CR>
 nnoremap cov :set <C-R>=(&virtualedit =~# "all") ? 'virtualedit-=all' : 'virtualedit+=all'<CR><CR>
+nnoremap [ol :setlocal list <C-R>=exists(':IndentLinesEnable') ? '<Bar> IndentLinesEnable' : ''<CR><CR>
+nnoremap ]ol :setlocal nolist <C-R>=exists(':IndentLinesDisable') ? '<Bar> IndentLinesDisable' : ''<CR><CR>
+nnoremap col :setlocal list! <C-R>=exists(':IndentLinesToggle') ? '<Bar> IndentLinesToggle' : ''<CR><CR>
 
 function! s:setup_paste() abort
   let s:paste = &paste

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -232,10 +232,6 @@ function! s:ve_options() abort
   return (&virtualedit =~# 'all') ? 'virtualedit-=all' : 'virtualedit+=all'
 endfunction
 
-function! s:indent_lines(cmd) abort
-  return exists(':IndentLines'.a:cmd) ? '| IndentLines'.a:cmd : ''
-endfunction
-
 function! s:fdc_options() abort
   return &foldcolumn == 0 ? 4 : 0
 endfunction
@@ -273,6 +269,7 @@ call s:option_map('n', 'number', 'setlocal')
 call s:option_map('r', 'relativenumber', 'setlocal')
 call s:option_map('s', 'spell', 'setlocal')
 call s:option_map('w', 'wrap', 'setlocal')
+call s:option_map('l', 'list', 'setlocal')
 call s:map('n', '[ov', ':set virtualedit+=all<CR>')
 call s:map('n', ']ov', ':set virtualedit-=all<CR>')
 call s:map('n', '=ov', ':set <C-R>=<SID>ve_options()<CR><CR>')
@@ -285,9 +282,6 @@ call s:map('n', '=of', ':setlocal foldcolumn=<C-R>=<SID>fdc_options()<CR><CR>')
 call s:map('n', '[oC', ':setlocal colorcolumn=+1<CR>')
 call s:map('n', ']oC', ':setlocal colorcolumn=<CR>')
 call s:map('n', '=oC', ':setlocal colorcolumn=<C-R>=<SID>cc_options()<CR><CR>')
-call s:map('n', '[ol', ':setlocal list <C-R>=<SID>indent_lines("Enable")<CR><CR>')
-call s:map('n', ']ol', ':setlocal nolist <C-R>=<SID>indent_lines("Disable")<CR><CR>')
-call s:map('n', '=ol', ':setlocal list! <C-R>=<SID>indent_lines("Toggle")<CR><CR>')
 if empty(maparg('co', 'n'))
   nmap co =o
 endif

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -167,21 +167,21 @@ nmap ]<Space> <Plug>unimpairedBlankDown
 function! s:Move(cmd, count, map) abort
   normal! m`
   silent! exe 'move'.a:cmd.a:count
-  norm! ``
+  norm! zx``
   silent! call repeat#set("\<Plug>unimpairedMove".a:map, a:count)
 endfunction
 
 function! s:MoveSelectionUp(count) abort
   normal! m`
   silent! exe "'<,'>move'<--".a:count
-  norm! ``
+  norm! zx``
   silent! call repeat#set("\<Plug>unimpairedMoveSelectionUp", a:count)
 endfunction
 
 function! s:MoveSelectionDown(count) abort
   normal! m`
   exe "'<,'>move'>+".a:count
-  norm! ``
+  norm! zx``
   silent! call repeat#set("\<Plug>unimpairedMoveSelectionDown", a:count)
 endfunction
 

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -16,7 +16,7 @@ endfunction
 " Next and previous {{{1
 
 function! s:MapNextFamily(map,cmd) abort
-  let key = (a:map ==# 'tab' ? '<Tab>' : a:map)
+  let key = (strlen(a:map) > 1 ? '<'.a:map.'>' : a:map)
   let map = '<Plug>unimpaired'.toupper(a:map)
   let cmd = '".(v:count ? v:count : "")."'.a:cmd
   let end = '"<CR>'.(a:cmd == 'l' || a:cmd == 'c' ? 'zv' : '')
@@ -26,8 +26,9 @@ function! s:MapNextFamily(map,cmd) abort
   execute 'nnoremap <silent> '.map.'Last     :<C-U>exe "'.cmd.'last'.end
   call s:map('n', '['.        key , map.'Previous')
   call s:map('n', ']'.        key , map.'Next')
-  call s:map('n', '['.(a:map ==# 'tab' ? '<S-Tab>' : toupper(key)), map.'First')
-  call s:map('n', ']'.(a:map ==# 'tab' ? '<S-Tab>' : toupper(key)), map.'Last')
+  let key = (strlen(a:map) > 1 ? '<S-'.a:map.'>' : toupper(a:map))
+  call s:map('n', '['.key, map.'First')
+  call s:map('n', ']'.key, map.'Last')
   if exists(':'.a:cmd.'nfile')
     execute 'nnoremap <silent> '.map.'PFile :<C-U>exe "'.cmd.'pfile'.end
     execute 'nnoremap <silent> '.map.'NFile :<C-U>exe "'.cmd.'nfile'.end
@@ -41,7 +42,7 @@ call s:MapNextFamily('b','b')
 call s:MapNextFamily('l','l')
 call s:MapNextFamily('q','c')
 call s:MapNextFamily('t','t')
-call s:MapNextFamily('tab', 'tab')
+call s:MapNextFamily('Tab', 'tab')
 
 function! s:entries(path)
   let path = substitute(a:path,'[\\/]$','','')


### PR DESCRIPTION
I have found vim-unimpaired to be indispensable so far, but I was missing some toggle mappings for options such as `colorcolumn` and `foldcolumn`, so I've added them.

Extending the metaphor for switching between buffers, I've also added mappings for `:tabnext`, `:tabprevious`, etc. Of course, there is `gt` and `gT`, but no mappings exist for `:tablast` and `:tabfirst`, so I thought they could fit in here quite nicely.

This PR also fixes a small bug that occurred when moving lines within folds with `]e` or `[e`. Unfortunately I'm not git-savvy enough to "extract" that commit (3784247) into a separate branch.