### PR TITLE
Make URL encoding Unicode safe

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -367,23 +367,13 @@ function! s:string_decode(str) abort
 endfunction
 
 function! s:url_encode(str) abort
-  let out = ''
-  let i = 0
-  while i < len(a:str)
-    let c = a:str[i]
-    if c =~# '[A-Za-z0-9_.~-]' || i == len(a:str) - 1 && c ==# "\n"
-      let out .= c
-    else
-      let out .= printf('%%%02X', char2nr(a:str[i]))
-    endif
-    let i += 1
-  endwhile
-  return out
+  " iconv trick to convert utf-8 bytes to 8bits indiviual char.
+  return substitute(iconv(a:str, 'latin1', 'utf-8'),'[^A-Za-z0-9_.~-]','\="%".printf("%02X",char2nr(submatch(0)))','g')
 endfunction
 
 function! s:url_decode(str) abort
   let str = substitute(substitute(substitute(a:str,'%0[Aa]\n$','%0A',''),'%0[Aa]','\n','g'),'+',' ','g')
-  return substitute(str,'%\(\x\x\)','\=nr2char("0x".submatch(1))','g')
+  return iconv(substitute(str,'%\(\x\x\)','\=nr2char("0x".submatch(1))','g'), 'utf-8', 'latin1')
 endfunction
 
 " HTML entities {{{2


### PR DESCRIPTION
I figure out a hack way of using iconv to convert utf-8 bytes to 8bits chars, and this can convert back. so since ensure the 8bits chars, original single byte implement should work too. this should truely fix #51 