### PR TITLE
Able to use `[n` and `]n` in visual mode

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -173,14 +173,8 @@ function! s:Context(reverse, visual) abort
     if lnum > 0
       execute 'normal! '.lnum.'G'
     else
-      execute 'normal! g`'.(cursor_on_top ? '<' : '>').'0'
-      " if nothing found, do a bunch of trickery to restore the cursor to
-      " where it was
-      if s:last_vcursor[4] == 2147483647
-        normal! $
-      elseif s:last_vcursor[2] > 1
-        execute 'normal! '.(s:last_vcursor[2] - 1).'l'
-      endif
+      execute 'normal! g`'.(cursor_on_top ? '<' : '>')
+      call setpos('.', s:last_vcursor)
     endif
   else
     call search(pattern, a:reverse ? 'bW' : 'W')


### PR DESCRIPTION
Hi,

This turned out to be more complicated than I expected since vim kicks you out of visual mode when trying to execute a command through a mapping, and then it moves the cursor around. :(

Is there a better way to set `curswant` if no match is found? Please let me know

Test plan:
- select an area **before** a marker with the cursor
  - on the bottom of the selection, press `]n`
  - [ ] selected text is from the marker to top of previous selection
  - on the top of the selection, press `]n`
  - [ ] selected text is from the marker to bottom of previous selection
- select an area **after** a marker with the cursor
  - on the bottom of the selection, press `[n`
  - [ ] selected text is from the marker to top of previous selection
  - on the top of the selection, press `[n`
  - [ ] selected text is from the marker to bottom of previous selection
- select an area on any side outside a marker with the cursor
  - on the bottom of the selection, press either `[n` or `]n`, whichever one is away from the marker
  - [ ] selected text and cursor should stay the same
  - on the top of the selection, press either `[n` or `]n`, whichever one is away from the marker
  - [ ] selected text and cursor should stay the same