### PR TITLE
add shortcut for delete line before after cursor line

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,8 +10,9 @@ commonly used ex commands. `]q` is :cnext. `[q` is :cprevious. `]a` is
 20 mappings and mnemonics.  All of them take a count.
 
 There are linewise mappings. `[<Space>` and `]<Space>` add newlines
-before and after the cursor line. `[e` and `]e` exchange the current
-line with the one above or below it.
+before and after the cursor line. `[d` and `]d` delete lines before and after
+the cursor line. `[e` and `]e` exchange the current line with the one above or
+below it.
 
 There are mappings for toggling options. `[os`, `]os`, and `=os` perform
 `:set spell`, `:set nospell`, and `:set invspell`, respectively.  There's also

--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -66,6 +66,12 @@ LINE OPERATIONS                                 *unimpaired-lines*
                                                 *]<Space>*
 ]<Space>                Add [count] blank lines below the cursor.
 
+                                                *[d*
+[d                      Delete [count] lines above the current line.
+
+                                                *]d*
+]d                      Delete [count] lines below the current line.
+
                                                 *[e* *v_[e*
 [e                      Exchange the current line with [count] lines above it.
 

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -178,6 +178,28 @@ endfunction
 
 " Section: Line operations
 
+function! s:DeleteUp(count) abort
+  normal! m`
+  silent! exe "normal! " . repeat(nr2char(107), a:count)
+  silent! exe "normal! " . repeat(nr2char(100), a:count * 2)
+  norm! ``
+  silent! call repeat#set("\<Plug>unimpairedDeleteUp", a:count)
+endfunction
+
+function! s:DeleteDown(count) abort
+  normal! m`
+  normal! j
+  silent! exe "normal! " . repeat(nr2char(100), a:count * 2)
+  norm! ``
+  silent! call repeat#set("\<Plug>unimpairedDeleteDown", a:count)
+endfunction
+
+nnoremap <silent> <Plug>unimpairedDeleteUp :<C-U>call <SID>DeleteUp(v:count1)<CR>
+nnoremap <silent> <Plug>unimpairedDeleteDown :<C-U>call <SID>DeleteDown(v:count1)<CR>
+
+call s:map('n', '[d', '<Plug>unimpairedDeleteUp')
+call s:map('n', ']d', '<Plug>unimpairedDeleteDown')
+
 function! s:BlankUp(count) abort
   put!=repeat(nr2char(10), a:count)
   ']+1


### PR DESCRIPTION
`[d` and `]d` to delete line(s) before and after cursor line.

supports variable count, vim-repeat