### PR TITLE
Reduce install steps when cloning into packpath

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,9 +36,7 @@ linewise mappings as well if you install
 Install using your favorite package manager, or use Vim's built-in package
 support:
 
-    mkdir -p ~/.vim/pack/tpope/start
-    cd ~/.vim/pack/tpope/start
-    git clone https://tpope.io/vim/unimpaired.git
+    git clone https://tpope.io/vim/unimpaired.git ~/.vim/pack/tpope/start/unimpaired
     vim -u NONE -c "helptags unimpaired/doc" -c q
 
 ## FAQ

--- a/README.markdown
+++ b/README.markdown
@@ -37,7 +37,7 @@ Install using your favorite package manager, or use Vim's built-in package
 support:
 
     git clone https://tpope.io/vim/unimpaired.git ~/.vim/pack/tpope/start/unimpaired
-    vim -u NONE -c "helptags unimpaired/doc" -c q
+    vim -u NONE -c "helptags ~/.vim/pack/tpope/start/unimpaired/doc" -c q
 
 ## FAQ
 


### PR DESCRIPTION
git: Cloning into an existing directory is only allowed if the directory is empty.
https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-ltdirectorygt