### PR TITLE
Fix: skip while loop if keys is empty

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -21,7 +21,7 @@ function! s:maps() abort
     if type(keys) != type({})
       continue
     endif
-    while !empty(head)
+    while !empty(head) && len(keys)
       if has_key(keys, head)
         let head = keys[head]
         if empty(head)


### PR DESCRIPTION
As discussed in #199 this conditional check will shave ~100ms loading time on slow machine.