### PR TITLE
Add mappings for :colder/:cnewer, :lolder/:lnewer

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -58,6 +58,13 @@ is "args" and for the "q" commands is "quickfix".
 ]n                      Go to the next SCM conflict marker or diff/patch hunk.
                         Try d]n inside a conflict.
 
+NEWER AND OLDER                                 *unimpaired-newer*
+
+*<q*     |:colder|
+*>q*     |:cnewer|
+*<l*     |:lolder|
+*>l*     |:lnewer|
+
 LINE OPERATIONS                                 *unimpaired-lines*
 
                                                 *[<Space>*

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -52,6 +52,12 @@ function! s:MapNextFamily(map,cmd) abort
   call s:map('n', ']'.        a:map , map.'Next')
   call s:map('n', '['.toupper(a:map), map.'First')
   call s:map('n', ']'.toupper(a:map), map.'Last')
+  if a:map ==# 'q' || a:map ==# 'l'
+    execute 'nnoremap <silent> '.map.'Newer :<C-U>exe "'.cmd.'newer'.end
+    execute 'nnoremap <silent> '.map.'Older :<C-U>exe "'.cmd.'older'.end
+    call s:map('n', '<'.a:map, map.'Older')
+    call s:map('n', '>'.a:map, map.'Newer')
+  endif
   if exists(':'.a:cmd.'nfile')
     execute 'nnoremap <silent> '.map.'PFile :<C-U>exe "'.cmd.'pfile'.end
     execute 'nnoremap <silent> '.map.'NFile :<C-U>exe "'.cmd.'nfile'.end


### PR DESCRIPTION
I use the `<q` and `>q` mappings often. The `<l` and `>l` mappings technically clobber a valid builtin, but they are synonymous with `<<` and `>>` ...