### PR TITLE
Allow to change next/prev mappings

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -65,11 +65,13 @@ function! s:MapNextFamily(map,cmd) abort
   endif
 endfunction
 
-call s:MapNextFamily('a','')
-call s:MapNextFamily('b','b')
-call s:MapNextFamily('l','l')
-call s:MapNextFamily('q','c')
-call s:MapNextFamily('t','t')
+let s:np_maps = { 'a': '', 'b': 'b', 'l': 'l', 'q': 'c', 't': 't' }
+if exists("g:unimpaired_np_maps")
+  call extend(s:np_maps, g:unimpaired_np_maps)
+endif
+for [key, map] in items(s:np_maps)
+  call s:MapNextFamily(key,map)
+endfor
 
 function! s:entries(path) abort
   let path = substitute(a:path,'[\\/]$','','')


### PR DESCRIPTION
User can override/extend next/previous mappings by defining dictionary
'g:unimpaired_np_maps' e.g.:

  let g:unimpaired_np_maps = { 't': 'tab' }

will change [t,]t,[T,]T mappings to work for tabs (_tab_prev,...)
instead of default mapping for tags (_t_prev,...).