### PR TITLE
Bugfix: Check loclist before quickfix so [f works in loclist

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -139,10 +139,10 @@ endfunction
 function! s:PreviousFileEntry(count) abort
   let window = s:GetWindow()
 
-  if get(window, 'quickfix')
-    return 'colder ' . a:count
-  elseif get(window, 'loclist')
+  if get(window, 'loclist')
     return 'lolder ' . a:count
+  elseif get(window, 'quickfix')
+    return 'colder ' . a:count
   else
     return 'edit ' . s:fnameescape(fnamemodify(s:FileByOffset(-v:count1), ':.'))
   endif
@@ -151,10 +151,10 @@ endfunction
 function! s:NextFileEntry(count) abort
   let window = s:GetWindow()
 
-  if get(window, 'quickfix')
-    return 'cnewer ' . a:count
-  elseif get(window, 'loclist')
+  if get(window, 'loclist')
     return 'lnewer ' . a:count
+  elseif get(window, 'quickfix')
+    return 'cnewer ' . a:count
   else
     return 'edit ' . s:fnameescape(fnamemodify(s:FileByOffset(v:count1), ':.'))
   endif


### PR DESCRIPTION
Fix [f in loclist fails gives message about quickfix instead of doing
:lolder

:h getwininfo() says:
    loclist		1 if showing a location list
    quickfix	1 if quickfix or location list window

Since quickfix is set for both types of windows, we need to check it last.

Repro:

    h getloc
    lgetbuffer
    h :lgetbuffer
    lgetbuffer
    lopen
    " at this point [f will fail but lolder will not