### PR TITLE
Add option mappings for a colorcolumn at textwidth+1

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -85,6 +85,7 @@ On	Off	Toggle	Option
 *[ol*	*]ol*	*yol*	'list'
 *[on*	*]on*	*yon*	'number'
 *[or*	*]or*	*yor*	'relativenumber'
+*[ot*	*]ot*	*yot*	'colorcolumn'+=+1 (colored column at `t`extwidth+1)
 *[ou*	*]ou*	*you*	'cursorcolumn'
 *[ov*	*]ov*	*yov*	'virtualedit'
 *[ow*	*]ow*	*yow*	'wrap'

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -335,7 +335,7 @@ call s:option_map('r', 'relativenumber', 'setlocal')
 call s:option_map('s', 'spell', 'setlocal')
 nmap <script> <Plug>(unimpaired-enable)t  :setlocal colorcolumn+=+1<CR>
 nmap <script> <Plug>(unimpaired-disable)t :setlocal colorcolumn-=+1<CR>
-nmap <script> <Plug>(unimpaired-toggle)t  :setlocal <C-R>=(&colorcolumn =~# '."'".'.*+1\%(\\|,.*\)'."'".') ? "colorcolumn-=+1" : "colorcolumn+=+1"<CR><CR>
+nmap <script> <Plug>(unimpaired-toggle)t  :setlocal <C-R>=(&colorcolumn =~# '\%\(.*,\)\=+1\%\(,.*\)\=') ? "colorcolumn-=+1" : "colorcolumn+=+1"<CR><CR>
 call s:option_map('w', 'wrap', 'setlocal')
 call s:option_map('z', 'spell', 'setlocal')
 nmap <script> <Plug>(unimpaired-enable)v  :<C-U>set virtualedit+=all<CR>

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -333,6 +333,9 @@ call s:option_map('l', 'list', 'setlocal')
 call s:option_map('n', 'number', 'setlocal')
 call s:option_map('r', 'relativenumber', 'setlocal')
 call s:option_map('s', 'spell', 'setlocal')
+nmap <script> <Plug>(unimpaired-enable)t  :setlocal colorcolumn+=+1<CR>
+nmap <script> <Plug>(unimpaired-disable)t :setlocal colorcolumn-=+1<CR>
+nmap <script> <Plug>(unimpaired-toggle)t  :setlocal <C-R>=(&colorcolumn =~# '."'".'.*+1\%(\\|,.*\)'."'".') ? "colorcolumn-=+1" : "colorcolumn+=+1"<CR><CR>
 call s:option_map('w', 'wrap', 'setlocal')
 call s:option_map('z', 'spell', 'setlocal')
 nmap <script> <Plug>(unimpaired-enable)v  :<C-U>set virtualedit+=all<CR>


### PR DESCRIPTION
Hi, I regularly toggle a colorcolumn at column `textwidth+1` when formatting text. This patch adds option mappings to set/unset/toggle this colorcolumn. This feature might be a little bit exotic, so feel free to close this pr.

PS: I am not sure whether the corresponding documentation is sufficient.