### PR TITLE
Provide `formatoptions+=t` option maps on "W" (hard wrap)

### DIFF
--- a/doc/unimpaired.txt
+++ b/doc/unimpaired.txt
@@ -90,6 +90,7 @@ On	Off	Toggle	Option
 *[ou*	*]ou*	*you*	'cursorcolumn'
 *[ov*	*]ov*	*yov*	'virtualedit'
 *[ow*	*]ow*	*yow*	'wrap'
+*[oW*	*]oW*	*yoW*	'formatoptions' has "t" (hard wrap)
 *[ox*	*]ox*	*yox*	'cursorline' 'cursorcolumn' (x as in crosshairs)
 
 The mnemonic for y is that if you tilt it a bit it looks like a switch.

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -340,6 +340,9 @@ endif
 nmap <script> <Plug>(unimpaired-enable)v  :<C-U>set virtualedit+=all<CR>
 nmap <script> <Plug>(unimpaired-disable)v :<C-U>set virtualedit-=all<CR>
 nmap <script> <Plug>(unimpaired-toggle)v  :<C-U>set <C-R>=(&virtualedit =~# "all") ? "virtualedit-=all" : "virtualedit+=all"<CR><CR>
+nmap <script> <Plug>(unimpaired-enable)W  :<C-U>set formatoptions+=t<CR>
+nmap <script> <Plug>(unimpaired-disable)W :<C-U>set formatoptions-=t<CR>
+nmap <script> <Plug>(unimpaired-toggle)W  :<C-U>set <C-R>=(&formatoptions =~# "t") ? "formatoptions-=t" : "formatoptions+=t"<CR><CR>
 nmap <script> <Plug>(unimpaired-enable)x  :<C-U>set cursorline cursorcolumn<CR>
 nmap <script> <Plug>(unimpaired-disable)x :<C-U>set nocursorline nocursorcolumn<CR>
 nmap <script> <Plug>(unimpaired-toggle)x  :<C-U>set <C-R>=<SID>CursorOptions()<CR><CR>


### PR DESCRIPTION
I use `set formatoptions+=t` and `set formatoptions-=t` quite often. Since it
resembles a hard wrap, I mapped it to the option map "W".
