### PR TITLE
Fix `[f` and `]f` behavior in directory containing `[`, `$`

### DIFF
--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -77,8 +77,9 @@ call s:MapNextFamily('t', 't', 'trewind')
 
 function! s:entries(path) abort
   let path = substitute(a:path,'[\\/]$','','')
-  let files = split(glob(fnameescape(path)."/.*"),"\n")
-  let files += split(glob(fnameescape(path)."/*"),"\n")
+  let path = substitute(path, '[[$*]', '[&]', 'g')
+  let files = split(glob(path."/.*"),"\n")
+  let files += split(glob(path."/*"),"\n")
   call map(files,'substitute(v:val,"[\\/]$","","")')
   call filter(files,'v:val !~# "[\\\\/]\\.\\.\\=$"')
 

--- a/plugin/unimpaired.vim
+++ b/plugin/unimpaired.vim
@@ -77,8 +77,8 @@ call s:MapNextFamily('t', 't', 'trewind')
 
 function! s:entries(path) abort
   let path = substitute(a:path,'[\\/]$','','')
-  let files = split(glob(path."/.*"),"\n")
-  let files += split(glob(path."/*"),"\n")
+  let files = split(glob(fnameescape(path)."/.*"),"\n")
+  let files += split(glob(fnameescape(path)."/*"),"\n")
   call map(files,'substitute(v:val,"[\\/]$","","")')
   call filter(files,'v:val !~# "[\\\\/]\\.\\.\\=$"')
 


### PR DESCRIPTION
Currently `s:entries()` lists file paths using `glob()` without escaping filename, so it works incorrectly when a directory name contains a special character such as `[` .   This PR fixes that and make `[f` and `]f` work for such directories.

